### PR TITLE
Prune table integer overflow detection

### DIFF
--- a/ACube/src/acube/prune/Prune.java
+++ b/ACube/src/acube/prune/Prune.java
@@ -35,12 +35,30 @@ public final class Prune {
     uEdgePos = createPruneTable(transform.uEdgePosTable);
     reporter.tableCreationStarted("pruning table (D edge position)");
     dEdgePos = createPruneTable(transform.dEdgePosTable);
-    final boolean combine_ct_ef = twist.stateSize() * flip.stateSize() <= MAX_TABLE_SIZE;
+    boolean combine_ct_ef;
+    try {
+      combine_ct_ef = Math.multiplyExact(twist.stateSize(), flip.stateSize()) <= MAX_TABLE_SIZE;
+    } catch(ArithmeticException e) {
+      combine_ct_ef = false;
+    }
     merged_twist_flip = combine_ct_ef ? new MoveTable2in1(transform.twistTable, transform.flipTable) : null;
-    final boolean combine_ct_cp = twist.stateSize() * cornerPos.stateSize() <= MAX_TABLE_SIZE;
+    
+    boolean combine_ct_cp;
+    try {
+      combine_ct_cp = Math.multiplyExact(twist.stateSize(), cornerPos.stateSize()) <= MAX_TABLE_SIZE;  
+    } catch(ArithmeticException e) {
+      combine_ct_cp = false;
+    } 
     merged_twist_cornerPos = combine_ct_cp ? new MoveTable2in1(transform.twistTable, transform.cornerPosTable) : null;
-    final boolean combine_ef_cp = flip.stateSize() * cornerPos.stateSize() <= MAX_TABLE_SIZE;
+    
+    boolean combine_ef_cp;
+    try {
+      combine_ef_cp = Math.multiplyExact(flip.stateSize(), cornerPos.stateSize()) <= MAX_TABLE_SIZE;      
+    } catch(ArithmeticException e) {
+      combine_ef_cp = false;
+    }
     merged_flip_cornerPos = combine_ef_cp ? new MoveTable2in1(transform.flipTable, transform.cornerPosTable) : null;
+    
     reporter.tableCreationStarted("pruning table (corner twist + edge flip)");
     twist_flip = createPruneTable(merged_twist_flip);
     reporter.tableCreationStarted("pruning table (corner twist + corner position)");


### PR DESCRIPTION
When using the optimal solver and ignoring certain sections of the cube, such as with this input file: [ac_bug_test.txt](https://github.com/josef-jelinek/acube/files/2237473/ac_bug_test.txt), the solver will crash with this stack trace:

```
...output elided...
|i| creating pruning table (edge flip + corner position)
Exception in thread "main" java.lang.NegativeArraySizeException
	at acube.prune.PruneTable.<init>(PruneTable.java:26)
	at acube.prune.Prune.createPruneTable(Prune.java:53)
	at acube.prune.Prune.<init>(Prune.java:49)
	at acube.CubeState.solveOptimal(CubeState.java:81)
	at acube.console.ACube.executeCommand(ACube.java:144)
	at acube.console.ACube.processFileInput(ACube.java:75)
	at acube.console.ACube.fileInput(ACube.java:61)
	at acube.console.ACube.main(ACube.java:41)
```
The source of this bug appears to be in Prune.java. 
Line 42: `final boolean combine_ef_cp = flip.stateSize() * cornerPos.stateSize() <= MAX_TABLE_SIZE;` does the right thing when `flip.stateSize() * cornerPos.stateSize()` fits in a 32 but integer, but erroneously returns true on integer overflow.

This patch catches the overflow and acts correctly. All 3 checks are probably not necessary, but figuring out which ones are necessary is difficult and error-prone.